### PR TITLE
Add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "type": "commonjs",
+  "homepage": "https://lumalabs.ai",
   "repository": "github:lumalabs/lumaai-node",
+  "bugs": {
+    "url": "https://github.com/lumalabs/lumaai-node/issues"
+  },
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [


### PR DESCRIPTION
## Summary
- add npm homepage metadata pointing to the Luma API documentation site
- add npm bugs metadata pointing to the repository issue tracker

## Verification
- node manifest assertion
- git diff --check
- npm pack --dry-run --json --ignore-scripts
